### PR TITLE
Prevent web page preview text from overflowing

### DIFF
--- a/src/components/middle/message/WebPage.scss
+++ b/src/components/middle/message/WebPage.scss
@@ -19,12 +19,6 @@
     border-radius: 2px;
   }
 
-  &-text {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
   .media-inner {
     margin: 0 !important;
     margin-bottom: 0.375rem !important;

--- a/src/components/middle/message/WebPage.tsx
+++ b/src/components/middle/message/WebPage.tsx
@@ -86,7 +86,7 @@ const WebPage: FC<OwnProps> = ({
           onCancelUpload={onCancelMediaTransfer}
         />
       )}
-      <div className="WebPage-text">
+      <div>
         <SafeLink className="site-name" url={url} text={siteName || displayUrl} />
         {!inPreview && title && (
           <p className="site-title">{renderText(title)}</p>


### PR DESCRIPTION
Fixes #20 

Removes styling from `WebPage-text` `div`. Use of `display: flex` on the parent was preventing `overflow` and `text-overflow` from taking effect

Before:
![image](https://user-images.githubusercontent.com/8657986/117794926-99567600-b245-11eb-82e5-e4824011b018.png)

After:
![image](https://user-images.githubusercontent.com/8657986/117795000-aa06ec00-b245-11eb-922d-fe964b72d06c.png)
