### PR TITLE
Add RTL support to input field and messages

### DIFF
--- a/src/components/middle/MiddleColumn.scss
+++ b/src/components/middle/MiddleColumn.scss
@@ -180,7 +180,7 @@
 
       #editable-message-text {
         text-align: justify;
-        direction: auto;
+        unicode-bidi: plaintext;
         height: 3.5rem !important;
 
         @media (max-width: 600px) {

--- a/src/components/middle/MiddleColumn.scss
+++ b/src/components/middle/MiddleColumn.scss
@@ -179,6 +179,8 @@
       }
 
       #editable-message-text {
+        text-align: justify;
+        direction: auto;
         height: 3.5rem !important;
 
         @media (max-width: 600px) {

--- a/src/components/middle/message/_message-content.scss
+++ b/src/components/middle/message/_message-content.scss
@@ -10,6 +10,8 @@
     margin: 0;
     word-break: break-word;
     line-height: 1.3125;
+    unicode-bidi: plaintext;
+    text-align: justify;
   }
 
   .theme-dark .Message.own & {


### PR DESCRIPTION
This is using the `dir=auto` algorithm in addition to `text-align: justify` to correct the global `text-align: left` that applies to this text field.

Tested with inspector, hoping that's not out of the standard for this project.

Fixing the smaller problem mentioned in #12.