### PR TITLE
Decrease login min phone number length to 7

### DIFF
--- a/src/components/auth/AuthPhoneNumber.tsx
+++ b/src/components/auth/AuthPhoneNumber.tsx
@@ -28,7 +28,7 @@ type DispatchProps = Pick<GlobalActions, (
   'setAuthPhoneNumber' | 'setAuthRememberMe' | 'loadNearestCountry' | 'clearAuthError' | 'gotToAuthQrCode'
 )>;
 
-const MIN_NUMBER_LENGTH = 10;
+const MIN_NUMBER_LENGTH = 7;
 
 let isPreloadInitiated = false;
 


### PR DESCRIPTION
There are phone numbers less than 10 digits.