### PR TITLE
refactor use runExclusive mutex interface

### DIFF
--- a/src/lib/gramjs/extensions/PromisedWebSockets.js
+++ b/src/lib/gramjs/extensions/PromisedWebSockets.js
@@ -116,16 +116,13 @@ class PromisedWebSockets {
 
     receive() {
         this.client.onmessage = async (message) => {
-            const release = await mutex.acquire();
-            try {
+            await mutex.runExclusive(async () => {
                 const data = message.data instanceof ArrayBuffer
                     ? Buffer.from(message.data)
                     : Buffer.from(await new Response(message.data).arrayBuffer());
                 this.stream = Buffer.concat([this.stream, data]);
                 this.resolveRead(true);
-            } finally {
-                release();
-            }
+            });
         };
     }
 }


### PR DESCRIPTION
since acquire/release is deprecated

see https://github.com/DirtyHairy/async-mutex/blob/d536a3313face4708bfe08660b4d8547b49f24bd/src/Mutex.ts#L23