### PR TITLE
Improve Ctrl+V image pasting

### DIFF
--- a/src/components/middle/composer/hooks/useClipboardPaste.ts
+++ b/src/components/middle/composer/hooks/useClipboardPaste.ts
@@ -24,7 +24,7 @@ export default (
       }
 
       const { items } = e.clipboardData;
-      const media = Array.from(items).find((item) => CLIPBOARD_ACCEPTED_TYPES.includes(item.type));
+      const media = Array.from(items).find((item) => CLIPBOARD_ACCEPTED_TYPES.includes(item.type) && item.kind == "file");
       const file = media && media.getAsFile();
       const pastedText = e.clipboardData.getData('text').substring(0, MAX_MESSAGE_LENGTH);
 


### PR DESCRIPTION
In some cases clipboardData.items contains broken item:
```
{type: "image/jpeg", "kind": "string"}
```