### PR TITLE
Handle resize options not being supported

### DIFF
--- a/src/util/imageResize.ts
+++ b/src/util/imageResize.ts
@@ -44,6 +44,9 @@ async function scale(
     try {
       const bitmap = await window.createImageBitmap(img,
         { resizeWidth: width, resizeHeight: height, resizeQuality: 'high' });
+      if (bitmap.width != width || bitmap.height != height) {
+        throw "not resized";
+      }
       return await new Promise((res) => {
         const canvas = document.createElement('canvas');
         canvas.width = bitmap.width;


### PR DESCRIPTION
FF93 supports the createImageBitmap options parameter but not all the options properties., specifically the resize options which are ignored.

As a result this leads to an infinite loop in [buildAttachment()](https://github.com/Ajaxy/telegram-tt/blob/baa0110b422abdb0af24e11171647931c3af2b9a/src/components/middle/composer/helpers/buildAttachment.ts#L30) which assumes that the resize has taken place.

This patch checks that the resize has actually happened and falls back to the previous method.