### PR TITLE
Keymap independant formatting shortcuts (fixes 10635)

### DIFF
--- a/src/components/middle/composer/TextFormatter.tsx
+++ b/src/components/middle/composer/TextFormatter.tsx
@@ -292,6 +292,15 @@ const TextFormatter: FC<OwnProps> = ({
     onClose();
   }
 
+	const keyFromEvent = (e: KeyboardEvent): string => {
+		if (e.hasOwnProperty('key')) return e.key;
+		if (e.code.startsWith("Key")) {
+			const key = e.code.slice(3);
+			return e.shiftKey || key.length > 1 ? key : key.tolowerCase();
+		}
+		return "";
+	}
+
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     const HANDLERS_BY_KEY: Record<string, AnyToVoidFunction> = {
       k: openLinkControl,
@@ -302,7 +311,7 @@ const TextFormatter: FC<OwnProps> = ({
       s: handleStrikethroughText,
     };
 
-    const handler = HANDLERS_BY_KEY[e.key];
+    const handler = HANDLERS_BY_KEY[keyFromEvent(e)];
 
     if (
       e.altKey


### PR DESCRIPTION
It builds, and I've tested the added function, but I haven't tested it all together.

Second commit can be excluded if pre-2016 compatibility (~2.5% global usage according to caniuse) isn't a concern.