### PR TITLE
Fix typo "csharp" lang alias for code highlighting

### DIFF
--- a/src/util/highlightCode.ts
+++ b/src/util/highlightCode.ts
@@ -8,7 +8,7 @@ const SUPPORTED_LANGUAGES = {
   bash: ['bash', 'sh'],
   c: ['c', 'h'],
   cpp: ['cpp', 'cc', 'c++', 'h++', 'hpp', 'hh', 'hxx', 'cxx'],
-  csharp: ['chasp', 'cs', 'c#'],
+  csharp: ['csharp', 'cs', 'c#'],
   css: ['css'],
   erlang: ['erlang', 'erl'],
   elixir: ['elixir', 'ex', 'exs'],


### PR DESCRIPTION
Simple typo fix. Also, C# highlighting doesn't even seem to work at all. I haven't tested many other languages highlighting, though, so maybe it's not the only one and you're already aware of it?