### PR TITLE
Code Highlight: Add support for Smalltalk language

### DIFF
--- a/src/util/highlightCode.ts
+++ b/src/util/highlightCode.ts
@@ -33,6 +33,7 @@ const SUPPORTED_LANGUAGES: Record<string, string[]> = {
   ruby: ['rb', 'gemspec', 'podspec', 'thor', 'irb'],
   rust: ['rs'],
   scss: [],
+  smalltalk: ['st'],
   sql: [],
   swift: [],
   twig: ['craftcms'],


### PR DESCRIPTION
This makes it possible to use syntax highlighting for the Smalltalk programming languages with the language codes `` ```smalltalk `` and `` ```st ``.

![image](https://user-images.githubusercontent.com/38782922/172909002-8206bf06-5d4e-4ab4-a528-d1de5623dee5.png)

