### PR TITLE
Read base url from ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ NODE_ENV=development
 
 TELEGRAM_T_API_ID=
 TELEGRAM_T_API_HASH=
+
+BASE_URL=https://web.telegram.org/z/

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,7 @@
   <meta property="twitter:description" content="Telegram is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
   <meta property="twitter:image" content="./<%= htmlWebpackPlugin.options.mainIcon %>.png">
 
-  <link rel="canonical" href="https://web.telegram.org/z/" />
+  <link rel="canonical" href="<%= htmlWebpackPlugin.options.baseUrl %>" />
   <link rel="apple-touch-icon" sizes="180x180" href="./<%= htmlWebpackPlugin.options.appleIcon %>.png">
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
   <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16x16.png">

--- a/src/index.html
+++ b/src/index.html
@@ -21,14 +21,14 @@
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://web.telegram.org/z/">
+  <meta property="og:url" content="<%= htmlWebpackPlugin.options.baseUrl %>">
   <meta property="og:title" content="<%= htmlWebpackPlugin.options.appName %>">
   <meta property="og:description" content="Telegram is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
   <meta property="og:image" content="./<%= htmlWebpackPlugin.options.mainIcon %>.png">
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image">
-  <meta property="twitter:url" content="https://web.telegram.org/z/">
+  <meta property="twitter:url" content="<%= htmlWebpackPlugin.options.baseUrl %>">
   <meta property="twitter:title" content="<%= htmlWebpackPlugin.options.appName %>">
   <meta property="twitter:description" content="Telegram is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
   <meta property="twitter:image" content="./<%= htmlWebpackPlugin.options.mainIcon %>.png">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,8 @@ const {
 
 dotenv.config();
 
+const { BASE_URL = 'https://web.telegram.org/z/' } = process.env;
+
 module.exports = (_env, { mode = 'production' }) => {
   return {
     mode,
@@ -145,6 +147,7 @@ module.exports = (_env, { mode = 'production' }) => {
         appleIcon: APP_ENV === 'production' ? 'apple-touch-icon' : 'apple-touch-icon-dev',
         mainIcon: APP_ENV === 'production' ? 'icon-192x192' : 'icon-dev-192x192',
         manifest: APP_ENV === 'production' ? 'site.webmanifest' : 'site_dev.webmanifest',
+        baseUrl: BASE_URL,
         template: 'src/index.html',
       }),
       new MiniCssExtractPlugin({


### PR DESCRIPTION
Currently the base url is hardcoded in `src/index.html`.

With this PR it is possible to specify BASE_URL via environmental variable or `.env` file.

If `BASE_URL` env var set, it will use it.
Otherwise it will read `BASE_URL` variable from `.env` file.
If none of the above set - `https://web.telegram.org/z/` is used by default.
