### PR TITLE
Add more file extensions

### DIFF
--- a/src/components/common/helpers/documentInfo.ts
+++ b/src/components/common/helpers/documentInfo.ts
@@ -32,14 +32,23 @@ export function getColorFromExtension(extension: string) {
     case 'apk':
     case 'xls':
     case 'xlsx':
+    case 'ods':
       return 'green';
     case 'zip':
     case 'rar':
     case '7z':
     case 'tar':
     case 'gz':
+    case 'bz2':
+    case 'liz':
+    case 'lz4':
+    case 'lz5':
+    case 'xz':
+    case 'zst':
+    case 'wim':
     case 'ppt':
     case 'pptx':
+    case 'odp':
       return 'orange';
     case 'pdf':
     case 'xps':


### PR DESCRIPTION
This PR adds color for some file extensions:
- ods is OpenDocument Spreadsheet
- odp is OpenDocument Presentation
- bz2, liz, lz4, lz5, xz, zst, wim are archive file extensions you can get from 7-zip