### PR TITLE
Update BASE_URL on .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ NODE_ENV=development
 TELEGRAM_T_API_ID=
 TELEGRAM_T_API_HASH=
 
-BASE_URL=https://web.telegram.org/z/
+BASE_URL=https://web.telegram.org/a/


### PR DESCRIPTION
Hey @Ajaxy

Currently, the actual base URL is `https://web.telegram.org/a/`.
I think we can update it on ".env.example" as well.