### PR TITLE
Fix chat scroll jump on message deletion or height change

### DIFF
--- a/src/components/middle/MessageList.tsx
+++ b/src/components/middle/MessageList.tsx
@@ -53,7 +53,7 @@ import {
 } from '../../global/selectors';
 import animateScroll, { isAnimatingScroll, restartCurrentScrollAnimation } from '../../util/animateScroll';
 import buildClassName from '../../util/buildClassName';
-import { orderBy } from '../../util/iteratees';
+import { findLast, orderBy } from '../../util/iteratees';
 import resetScroll from '../../util/resetScroll';
 import { debounce, onTickEnd } from '../../util/schedulers';
 import { groupMessages } from './helpers/groupMessages';
@@ -365,6 +365,26 @@ const MessageList: FC<OwnProps & StateProps> = ({
   const rememberScrollPositionRef = useStateRef(() => {
     if (!messageIds || !listItemElementsRef.current) {
       return;
+    }
+
+    if (containerRef.current) {
+      const container = containerRef.current;
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const scrollable = clientHeight < scrollHeight;
+
+      // find first element that is visible in viewport
+      const topElement = !scrollable
+        ? ""
+        : findLast(
+            listItemElementsRef.current,
+            (elem) => elem.offsetTop < scrollTop
+        );
+      
+      if (topElement) {
+        anchorIdRef.current = topElement.id;
+        anchorTopRef.current = topElement.getBoundingClientRect().top;
+        return;
+      }
     }
 
     const preservedItemElements = listItemElementsRef.current


### PR DESCRIPTION
This pull request addresses an issue where the chat scroll jumps when a message above the viewport is deleted or its height changes due to an edit.

To resolve this problem, I have implemented a solution in the MessageList component. The fix involves setting the anchor to the top element in the viewport. By doing so, we ensure that the scroll position is preserved even if messages above viewport are modified or removed.

Please review the changes and let me know if any further adjustments are needed. I'm open to feedback and eager to collaborate on improving the Telegram Web experience.