### PR TITLE
Fix border-radius of the compact menu

### DIFF
--- a/src/components/ui/Menu.scss
+++ b/src/components/ui/Menu.scss
@@ -88,7 +88,7 @@
     .bubble {
       background: var(--color-background-compact-menu);
       backdrop-filter: blur(10px);
-      padding: 0.25rem 0;
+      padding: 0.125rem 0;
 
       body.no-menu-blur & {
         background: var(--color-background);

--- a/src/components/ui/MenuItem.scss
+++ b/src/components/ui/MenuItem.scss
@@ -129,7 +129,7 @@
     font-size: 0.875rem;
     margin: 0.125rem 0.25rem;
     padding: 0.25rem;
-    border-radius: 0.375rem;
+    border-radius: 0.5rem;
     width: auto;
     font-weight: 500;
     transform: scale(1);


### PR DESCRIPTION
Now the outer radius matches the inner one

| Before| After |
|--------|--------|
| ![image](https://github.com/Ajaxy/telegram-tt/assets/18244287/8bc4e74f-125f-480f-bc81-8be082e349d2) | ![image](https://github.com/Ajaxy/telegram-tt/assets/18244287/5bfa08a2-9e22-4024-bc8d-4542dd7c0868) |
