### PR TITLE
Composer: Add check for empty input to prevent errors on delete action

### DIFF
--- a/src/components/common/Composer.tsx
+++ b/src/components/common/Composer.tsx
@@ -1271,8 +1271,10 @@ const Composer: FC<OwnProps & StateProps> = ({
   });
 
   const removeSymbol = useLastCallback((inInputId = editableInputId) => {
-    const selection = window.getSelection()!;
+    const html = getHtml();
+    if (!html) return;
 
+    const selection = window.getSelection()!;
     if (selection.rangeCount) {
       const selectionRange = selection.getRangeAt(0);
       if (isSelectionInsideInput(selectionRange, inInputId)) {
@@ -1281,7 +1283,7 @@ const Composer: FC<OwnProps & StateProps> = ({
       }
     }
 
-    setHtml(deleteLastCharacterOutsideSelection(getHtml()));
+    setHtml(deleteLastCharacterOutsideSelection(html));
   });
 
   const removeSymbolAttachmentModal = useLastCallback(() => {

--- a/src/util/deleteLastCharacterOutsideSelection.ts
+++ b/src/util/deleteLastCharacterOutsideSelection.ts
@@ -16,14 +16,19 @@ export default function deleteLastCharacterOutsideSelection(html: string) {
     }
   }
 
-  // Gets length of the element's content.
-  const textLength = element.textContent!.length;
   const range = document.createRange();
   const selection = window.getSelection()!;
 
-  // Sets selection position to the end of the element.
-  range.setStart(element, textLength);
-  range.setEnd(element, textLength);
+  if (element.textContent === "") {
+    range.selectNode(element);
+  } else {
+    // Gets length of the element's content.
+    const textLength = element.textContent!.length;
+    // Sets selection position to the end of the element.
+    range.setStart(element, textLength);
+    range.setEnd(element, textLength);
+  }
+
   selection.removeAllRanges();
   selection.addRange(range);
   document.execCommand('delete', false);


### PR DESCRIPTION
This PR fixes #363.

Also fixed two issues shown in the video below:

1. Unable to delete when only one emoji is left.
2. Deleted the wrong emoji when there are multiple emojis.

https://github.com/Ajaxy/telegram-tt/assets/77763617/b93839b3-cb65-4754-97c1-7a6e4fbbfeeb