### PR TITLE
fix: bad casing of services messages chat label

### DIFF
--- a/src/global/helpers/users.ts
+++ b/src/global/helpers/users.ts
@@ -69,7 +69,7 @@ export function getUserStatus(
   lang: LangFn, user: ApiUser, userStatus: ApiUserStatus | undefined,
 ) {
   if (user.id === SERVICE_NOTIFICATIONS_USER_ID) {
-    return lang('ServiceNotifications').toLowerCase();
+    return lang('ServiceNotifications');
   }
 
   if (user.isSupport) {


### PR DESCRIPTION
Fixes bad casing of the “service messages” label in the chat with service notifications. This bug only happens in languages that use uppercase letters in this string, such as German: https://translations.telegram.org/de/weba/private_chats/ServiceNotifications