### PR TITLE
Fix markMentionsRead() for albums and action messages

### DIFF
--- a/src/components/middle/ActionMessage.tsx
+++ b/src/components/middle/ActionMessage.tsx
@@ -128,6 +128,7 @@ const ActionMessage: FC<OwnProps & StateProps> = ({
     getReceipt,
     openGiftInfoModalFromMessage,
     openPrizeStarsTransactionFromGiveaway,
+    markMentionsRead,
   } = getActions();
 
   const oldLang = useOldLang();
@@ -194,6 +195,12 @@ const ActionMessage: FC<OwnProps & StateProps> = ({
       requestConfetti({ withStars: true });
     }
   }, [isVisible, requestConfetti]);
+
+  useEffect(() => {
+    if (isVisible && message.hasUnreadMention) {
+      markMentionsRead({ messageIds: [message.id] });
+    }
+  }, [message.hasUnreadMention, isVisible]);
 
   const { transitionClassNames } = useShowTransitionDeprecated(isShown, undefined, noAppearanceAnimation, false);
 

--- a/src/components/middle/message/Message.tsx
+++ b/src/components/middle/message/Message.tsx
@@ -850,8 +850,21 @@ const Message: FC<OwnProps & StateProps> = ({
       animateUnreadReaction({ messageIds: [messageId] });
     }
 
+    const unreadMentionsIds: number[] = [];
     if (message.hasUnreadMention) {
-      markMentionsRead({ messageIds: [messageId] });
+      unreadMentionsIds.push(message.id);
+    }
+
+    if (album) {
+      for (const albumMessage of album.messages) {
+        if (albumMessage.hasUnreadMention) {
+          unreadMentionsIds.push(albumMessage.id);
+        }
+      }
+    }
+
+    if (unreadMentionsIds.length) {
+      markMentionsRead({ messageIds: unreadMentionsIds });
     }
   }, [hasUnreadReaction, messageId, animateUnreadReaction, message.hasUnreadMention]);
 


### PR DESCRIPTION
This PR fixes two related but independent issues.

1. For “system” messages (ActionMessage) the `markMentionsRead()` is never called.

2. For messages with albums (which actually consist of multiple messages), `markMentionsRead()` was called only for the first message, and not for all submessages.

Both these problems create problem, where unread mentions are just accumulated to infinity.
In my opinion, this is the most annoying bug in Telegram Web.