### PR TITLE
Paid Reactions: immutable unshift

### DIFF
--- a/src/components/middle/message/reactions/ReactionPickerLimited.tsx
+++ b/src/components/middle/message/reactions/ReactionPickerLimited.tsx
@@ -100,7 +100,9 @@ const ReactionPickerLimited: FC<OwnProps & StateProps> = ({
 
     const reactionsToSort: ApiReactionWithPaid[] = enabledReactions.allowed;
     if (isWithPaidReaction) {
-      reactionsToSort.unshift({ type: 'paid' });
+      const reactionPaid = { type: 'paid' } as ApiReactionWithPaid;
+      const reactionsWithPaid = [reactionPaid].concat(reactionsToSort);
+      return sortReactions(reactionsWithPaid, topReactions);
     }
 
     return sortReactions(reactionsToSort, topReactions);


### PR DESCRIPTION
Repairs https://github.com/Ajaxy/telegram-tt/issues/418.

`enabledReactions.allowed` was mutated on every render of the picker because of shallow copy in https://github.com/Ajaxy/telegram-tt/blob/a8ef2c245a4ddaa7bd26518a072ae735f51111cf/src/components/middle/message/reactions/ReactionPickerLimited.tsx#L101.

replaced unshift with immutable concat, now `enabledReactions.allowed` stays the same.

I've also considered making a spread of `[ ...enabledReactions.allowed ]` but the spread is also a code smell, concat is more idiomatic for immutable js.

There is also a [replacement](https://github.com/fetsorn/telegram-tt/commit/9890bb6b5053bd89a5e838727e034fb7e9f9055c) for all `unshift.({type: "paid"})` in the `unshift_all` branch because mutating like that is a code smell. But it's out of scope of this bugfix, feel free to communicate if it's of any value for another PR.