### PR TITLE
add async counter messages by chats

### DIFF
--- a/src/components/left/main/ChatBadge.scss
+++ b/src/components/left/main/ChatBadge.scss
@@ -112,4 +112,8 @@
     padding: 0.25rem 1rem 0.375rem 1rem !important;
     z-index: calc(var(--z-chat-ripple) + 1);
   }
+
+  &_ownCounter {
+    background-color: #9e8b50;
+  }
 }


### PR DESCRIPTION
Counting the number of all my messages in chats of type
group and private chat.

The count starts when the chat object enters the
viewport.
At the beginning of the count, display a banner with the text
"Counting messages".
When the count is complete, display the number of messages.

![localhost_1234_ (3)](https://github.com/user-attachments/assets/3587538e-e36d-4aa0-af69-ad527c6830b5)

When typing in chat its revoke, but its not observing by chats all time.

![localhost_1234_ (4)](https://github.com/user-attachments/assets/62fb82b7-447c-4f9f-80e8-43bbc77906c2)
