### PR TITLE
Hotfix/swipe ios bug

### DIFF
--- a/src/util/captureEvents.ts
+++ b/src/util/captureEvents.ts
@@ -125,6 +125,8 @@ export function captureEvents(element: HTMLElement, options: CaptureOptions) {
   const minZoom = options.minZoom ?? 1;
   const maxZoom = options.maxZoom ?? 4;
 
+  let isNearEdge = false; // Add this flag
+
   function onCapture(e: MouseEvent | RealTouchEvent) {
     const target = e.target as HTMLElement;
     const {
@@ -162,6 +164,11 @@ export function captureEvents(element: HTMLElement, options: CaptureOptions) {
       document.addEventListener('mousemove', onMove);
       document.addEventListener('mouseup', onRelease);
     } else if (e.type === 'touchstart') {
+      if (IS_IOS) {
+        const x = (e as RealTouchEvent).touches[0].pageX;
+        isNearEdge = x <= IOS_SCREEN_EDGE_THRESHOLD || x >= windowSize.get().width - IOS_SCREEN_EDGE_THRESHOLD;
+      }
+
       // We need to always listen on `touchstart` target:
       // https://stackoverflow.com/questions/33298828/touch-move-event-dont-fire-after-touch-start-target-is-removed
       target.addEventListener('touchmove', onMove, { passive: true });
@@ -249,6 +256,7 @@ export function captureEvents(element: HTMLElement, options: CaptureOptions) {
       y: newWindowSize.height / 2,
     };
     captureEvent = undefined;
+    isNearEdge = false;
   }
 
   function onMove(e: MouseEvent | RealTouchEvent) {
@@ -313,12 +321,8 @@ export function captureEvents(element: HTMLElement, options: CaptureOptions) {
   }
 
   function onSwipe(e: MouseEvent | RealTouchEvent, dragOffsetX: number, dragOffsetY: number) {
-    // Avoid conflicts with swipe-to-back gestures
-    if (IS_IOS) {
-      const x = (e as RealTouchEvent).touches[0].pageX;
-      if (x <= IOS_SCREEN_EDGE_THRESHOLD || x >= windowSize.get().width - IOS_SCREEN_EDGE_THRESHOLD) {
-        return false;
-      }
+    if (IS_IOS && isNearEdge) {
+      return false;
     }
 
     const xAbs = Math.abs(dragOffsetX);

--- a/src/util/captureEvents.ts
+++ b/src/util/captureEvents.ts
@@ -125,7 +125,7 @@ export function captureEvents(element: HTMLElement, options: CaptureOptions) {
   const minZoom = options.minZoom ?? 1;
   const maxZoom = options.maxZoom ?? 4;
 
-  let isNearEdge = false; // Add this flag
+  let isNearEdge = false;
 
   function onCapture(e: MouseEvent | RealTouchEvent) {
     const target = e.target as HTMLElement;


### PR DESCRIPTION
## Fix iOS swipe-to-back gesture conflict with message drafts

### Problem
iOS swipe-to-back gesture was accidentally triggering message draft replies due to late edge detection.

### Solution
- Moved iOS edge detection from `onSwipe` to `onCapture` (touch start)
- Added `isNearEdge` flag to prevent swipe processing when touch starts near screen edges
- Early return in `onSwipe` when edge touch detected

### Result
- iOS swipe-to-back no longer triggers drafts
- Message drafts still work when touching away from edges
- No impact on other platforms
