### PR TITLE
open context menu only on avatar

### DIFF
--- a/src/components/middle/message/SenderGroupContainer.tsx
+++ b/src/components/middle/message/SenderGroupContainer.tsx
@@ -133,7 +133,7 @@ const SenderGroupContainer: FC<OwnProps & StateProps> = ({
     isContextMenuOpen, contextMenuAnchor,
     handleContextMenu, handleContextMenuClose,
     handleContextMenuHide,
-  } = useContextMenuHandlers(ref);
+  } = useContextMenuHandlers(avatarRef);
 
   const getTriggerElement = useLastCallback(() => avatarRef.current);
   const getRootElement = useLastCallback(() => document.querySelector('.Transition_slide-active > .MessageList'));


### PR DESCRIPTION
## Fix: Prevent double context menus on mobile in group chats

### Problem
On mobile devices, when long-pressing on a message in a group chat, two context menus were appearing simultaneously:
1. The main message context menu (upper menu)
2. The sender avatar context menu (lower menu)

This caused the menus to overlap and interfere with each other, making it impossible to interact with the message context menu menu.

### Root Cause
The `SenderGroupContainer` component was attaching its context menu handlers to the entire container (`ref`) instead of just the avatar element (`avatarRef`). This meant that when users long-pressed anywhere on the message group, both the message's context menu and the avatar's context menu would trigger.

### Solution
Changed the context menu handler attachment from `ref` to `avatarRef` in `SenderGroupContainer.tsx`:

```tsx
// Before
} = useContextMenuHandlers(ref);

// After  
} = useContextMenuHandlers(avatarRef);
```

### Result
- Long-pressing on the avatar now opens only the avatar context menu (Send Message, Mention)
- Long-pressing on the message content opens only the message context menu (Reply, Copy, Forward, etc.)
- No more overlapping menus or interaction conflicts

### Testing
- Tested on mobile devices with group chats
- Verified avatar context menu opens only when long-pressing the avatar
- Verified message context menu opens only when long-pressing message content
- Confirmed no double menu triggers occur

before
<img width="333" height="728" alt="image" src="https://github.com/user-attachments/assets/0b15617f-f5fd-474d-8a4d-d85387f4852d" />


