### PR TITLE
fix: Add support for disappearing photos (#349)

### DIFF
--- a/src/api/gramjs/methods/messages.ts
+++ b/src/api/gramjs/methods/messages.ts
@@ -949,6 +949,7 @@ async function uploadMedia(message: ApiMessage, attachment: ApiAttachment, onPro
         return new GramJs.InputMediaUploadedPhoto({
           file: inputFile,
           spoiler: shouldSendAsSpoiler,
+          ttlSeconds,
         });
       }
 


### PR DESCRIPTION
## Description
Fixes #349 - Adds support for disappearing photos (time-to-live media)

## Changes
- Added `ttlSeconds` parameter to `InputMediaUploadedPhoto` constructor in `messages.ts`
- This matches the existing implementation for `InputMediaUploadedDocument`

## Testing
- ✅ Disappearing photos now work correctly
- ✅ Timer can be set before sending
- ✅ Photos disappear after viewing as expected

## Background
Telegram introduced disappearing media 7 years ago, but Web A has never supported it. This was a simple 1-line fix to enable the feature.