### PR TITLE
fix: enable undo for pasted text by using execCommand

### DIFF
--- a/src/util/selection.ts
+++ b/src/util/selection.ts
@@ -4,6 +4,11 @@ export function insertHtmlInSelection(html: string) {
   const selection = window.getSelection();
 
   if (selection?.getRangeAt && selection.rangeCount) {
+    // Attempt to use execCommand for undo support
+    if (document.execCommand && document.execCommand('insertHTML', false, html)) {
+      return;
+    }
+
     const range = selection.getRangeAt(0);
     range.deleteContents();
 


### PR DESCRIPTION
This PR fixes an issue where pasted text could not be undone using Ctrl+Z. It modifies insertHtmlInSelection to use document.execCommand("insertHTML") which preserves the browser undo history.