### PR TITLE
Save empty username

### DIFF
--- a/src/components/left/settings/SettingsEditProfile.tsx
+++ b/src/components/left/settings/SettingsEditProfile.tsx
@@ -194,7 +194,7 @@ const SettingsEditProfile = ({
     const trimmedLastName = lastName.trim();
     const trimmedBio = bio.trim();
 
-    if (!editableUsername) return;
+    if (editableUsername === false) return;
 
     if (!trimmedFirstName.length) {
       setError(ERROR_FIRST_NAME_MISSING);


### PR DESCRIPTION
Fixes #503 

**Problem**:
In the desktop/mobile client, you can clear the username field and save, and the user's username gets removed. In the web client this doesn't work

**Cause**:
In the settings save handler there was a check like if (!editableUsername) return, but this isn't quite correct, since editableUsername can be not only false, but also  

**Fix**:
A stricter check editableUsername === false

**How to test:**
1. open the settings modal
2. enter an empty string instead of the username
3. save

Expected behavior:
- the username field is empty
- when reopening the settings modal, the username field is absent