### PR TITLE
Avatar: Fix 1px colored ring around avatars

### DIFF
--- a/src/components/common/Avatar.scss
+++ b/src/components/common/Avatar.scss
@@ -59,8 +59,22 @@
     width: 100%;
     height: 100%;
     border-radius: var(--radius);
+  }
+
+  > .inner::before {
+    content: "";
+
+    position: absolute;
+    z-index: -1;
+    inset: 0;
+
+    border-radius: var(--radius);
 
     background-image: linear-gradient(var(--color-white) -300%, var(--color-user));
+  }
+
+  &.with-media > .inner::before {
+    inset: 1px;
   }
 
   &__media {
@@ -160,7 +174,7 @@
     --color-user: var(--color-deleted-account);
   }
 
-  &.premium-gradient-bg > .inner {
+  &.premium-gradient-bg > .inner::before {
     background-image: var(--premium-gradient);
   }
 

--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -281,6 +281,7 @@ const Avatar = ({
     isRoundedRect && 'forum',
     asMessageBubble && 'message-bubble',
     (photo || webPhoto) && 'force-fit',
+    (!specialIcon && hasBlobUrl) && 'with-media',
     ((withStory && realPeer?.hasStories) || forPremiumPromo) && 'with-story-circle',
     withStorySolid && realPeer?.hasStories && 'with-story-solid',
     withStorySolid && forceFriendStorySolid && 'close-friend',


### PR DESCRIPTION
Occasionally a very thin ~1px colored ring appears at the edge of a circular avatar right after it is set, changed, or re-rendered. The color is not constant, it differs per chat/peer.

Before:

<img width="730" height="324" alt="image" src="https://github.com/user-attachments/assets/a483682c-5cd2-4692-94ea-a822a961d863" />

After:

<img width="1010" height="354" alt="image" src="https://github.com/user-attachments/assets/54e9c382-441e-430a-bbd8-37958ba5706f" />
