### PR TITLE
fix(group-calls): clear chat entity call fields on end

### DIFF
--- a/src/api/gramjs/updates/mtpUpdateHandler.ts
+++ b/src/api/gramjs/updates/mtpUpdateHandler.ts
@@ -993,6 +993,7 @@ export function updater(update: Update) {
     sendApiUpdate({
       '@type': 'updateGroupCall',
       call: buildApiGroupCall(update.call),
+      chatId: update.peer ? getApiChatIdFromMtpPeer(update.peer) : undefined,
     });
   } else if (update instanceof GramJs.UpdateGroupCallConnection) {
     sendApiUpdate({

--- a/src/api/types/updates.ts
+++ b/src/api/types/updates.ts
@@ -662,6 +662,7 @@ export type ApiUpdateServerTimeOffset = {
 export type ApiUpdateGroupCall = {
   '@type': 'updateGroupCall';
   call: ApiGroupCall;
+  chatId?: string;
 };
 
 export type ApiUpdateGroupCallChatId = {

--- a/src/global/actions/apiUpdaters/calls.ts
+++ b/src/global/actions/apiUpdaters/calls.ts
@@ -18,9 +18,17 @@ addActionHandler('apiUpdate', (global, actions, update): ActionReturnType => {
   switch (update['@type']) {
     case 'updateGroupCall': {
       if (update.call.connectionState === 'discarded') {
+        const chatId = update.chatId ?? selectGroupCall(global, update.call.id)?.chatId;
+        if (chatId) {
+          global = updateChat(global, chatId, {
+            isCallActive: undefined,
+            isCallNotEmpty: undefined,
+          });
+        }
+
         if (global.groupCalls.activeGroupCallId) {
           if ('leaveGroupCall' in actions) actions.leaveGroupCall({ shouldRemove: true, tabId: getCurrentTabId() });
-          return undefined;
+          return global;
         } else {
           return removeGroupCall(global, update.call.id);
         }


### PR DESCRIPTION
"Join group call" button doesn't change to "Start group call" when a group call ends