### PR TITLE
Fix delete-confirmation modal hidden behind media viewer

### DIFF
--- a/src/components/mediaViewer/MediaViewerActions.tsx
+++ b/src/components/mediaViewer/MediaViewerActions.tsx
@@ -253,6 +253,9 @@ const MediaViewerActions: FC<OwnProps & StateProps> = ({
 
   const openDeleteModalHandler = useLastCallback(() => {
     if (item?.type === 'message' && chat) {
+      // Close the viewer first: the shared delete-confirmation modal is rendered in the main
+      // app layer, which is stacked below the media viewer, so it would otherwise be occluded.
+      onCloseMediaViewer();
       openDeleteMessageModal({
         chatId: chat?.id,
         messageIds: [item.message.id],


### PR DESCRIPTION
## Fixes #515

Deleting a message from inside the full-screen media viewer looked broken: clicking the Trash button opened the delete-confirmation modal **behind** the viewer, so it was invisible until the viewer was closed.

### Root cause

For a message, `MediaViewerActions` dispatches the global `openDeleteMessageModal` action. That modal is rendered up in `Main` and portaled into the shared `#portals` container at the default `--z-modal` tier (`1510`), while the media viewer's top surface sits at `calc(var(--z-modal) + 1)` (`1511`) — so the confirmation is stacked underneath it. Avatar deletion doesn't hit this because it renders a *local* `DeleteProfilePhotoModal` inside the viewer.

### Fix

Close the media viewer when a message delete is initiated from within it, so the confirmation appears on the normal chat surface where it's always visible. This uses the existing `onCloseMediaViewer` handler (the same one the Close button uses) and matches the existing flow, which already closes the viewer once a deletion is confirmed.

I kept this to the minimal behavioral change rather than raising the shared modal's z-index globally, since `DeleteMessageModal` is used from several other places (context menu, message editing, selection toolbar, reactor list) and I didn't want to risk side effects there. Happy to switch to rendering a local modal inside the viewer instead if you'd prefer that approach.

### Testing

- `tsc` and `eslint` clean on the change
- `npm run build:mocked` builds successfully
- Verified against the avatar path, which already renders its delete modal locally and correctly — this change moves the message path onto the same always-visible surface.
