### PR TITLE
Tab List: Add tab semantics and arrow key navigation

### DIFF
--- a/src/components/middle/composer/FormattedDateModal.tsx
+++ b/src/components/middle/composer/FormattedDateModal.tsx
@@ -190,6 +190,7 @@ const FormattedDateModal = ({
               className={buildClassName(styles.tabList, areOtherDateOptionsDisabled && styles.tabListDisabled)}
               tabs={formatTabs}
               activeTab={activeDateTab}
+              isDisabled={areOtherDateOptionsDisabled}
               onSwitchTab={handleDateStyleChange}
             />
           </div>
@@ -200,6 +201,7 @@ const FormattedDateModal = ({
               className={buildClassName(styles.tabList, areOtherDateOptionsDisabled && styles.tabListDisabled)}
               tabs={formatTabs}
               activeTab={activeTimeTab}
+              isDisabled={areOtherDateOptionsDisabled}
               onSwitchTab={handleTimeStyleChange}
             />
           </div>

--- a/src/components/ui/TabList.module.scss
+++ b/src/components/ui/TabList.module.scss
@@ -93,6 +93,11 @@
       opacity: 0.85;
     }
 
+    &:focus-visible {
+      outline: 0.125rem solid var(--color-primary);
+      outline-offset: -0.125rem;
+    }
+
     .activeIndicator & {
       color: var(--color-primary);
     }

--- a/src/components/ui/TabList.tsx
+++ b/src/components/ui/TabList.tsx
@@ -8,6 +8,7 @@ import type { TabWithProperties } from './SquareTabList';
 export type { TabWithProperties };
 
 import buildClassName from '../../util/buildClassName';
+import focusNoScroll from '../../util/focusNoScroll';
 import renderText from '../common/helpers/renderText';
 
 import useFlag from '../../hooks/useFlag';
@@ -89,8 +90,30 @@ const TabList = ({
 
   useScrollToActiveTab(containerRef, activeTab);
 
+  // A tab list holds a single tab stop, which falls back to the first tab while `activeTab` points outside the list
+  const focusableTab = activeTab >= 0 && activeTab < tabs.length ? activeTab : 0;
+
   const handleTabClick = useLastCallback((index: number) => {
     onSwitchTab(index);
+  });
+
+  const handleKeyDown = useLastCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    const isNext = e.key === 'ArrowRight';
+    if (!isNext && e.key !== 'ArrowLeft') return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    e.preventDefault();
+
+    // Focus leads activation, so the focused tab is the reliable starting point while `activeTab` catches up
+    const tabElements = Array.from(container.children);
+    const focusedIndex = tabElements.indexOf(e.target as Element);
+    const currentIndex = focusedIndex >= 0 && focusedIndex < tabs.length ? focusedIndex : focusableTab;
+    const newIndex = (currentIndex + (isNext ? 1 : -1) + tabs.length) % tabs.length;
+
+    onSwitchTab(newIndex);
+    focusNoScroll(tabElements[newIndex] as HTMLElement | undefined);
   });
 
   const handleContextMenu = useLastCallback((index: number, e: React.MouseEvent) => {
@@ -123,7 +146,8 @@ const TabList = ({
 
   const hasContextActions = tabs.some((tab) => tab.contextActions?.length);
 
-  const renderTab = (tab: TabWithProperties, index: number) => {
+  // The active indicator renders a mirrored copy of every tab, so those copies stay out of the accessibility tree
+  const renderTab = (tab: TabWithProperties, index: number, noInteractive?: boolean) => {
     const customEmojiId = tab.customEmojiDocumentId
       || (typeof tab.emoticon === 'object' ? tab.emoticon.documentId : undefined);
     const stringEmoticon = typeof tab.emoticon === 'string' ? tab.emoticon : undefined;
@@ -137,6 +161,9 @@ const TabList = ({
           itemAlignment === 'vertical' && styles.vertical,
           stretched && styles.stretched,
         )}
+        role={noInteractive ? undefined : 'tab'}
+        tabIndex={noInteractive ? undefined : (index === focusableTab ? 0 : -1)}
+        aria-selected={noInteractive ? undefined : index === activeTab}
         onClick={() => handleTabClick(index)}
         onContextMenu={hasContextActions ? (e) => handleContextMenu(index, e) : undefined}
       >
@@ -162,6 +189,7 @@ const TabList = ({
   const tabListElement = (
     <div
       ref={containerRef}
+      role="tablist"
       className={buildClassName(
         'TabList',
         styles.container,
@@ -171,8 +199,9 @@ const TabList = ({
         className,
         clipPath && styles.ready,
       )}
+      onKeyDown={handleKeyDown}
     >
-      {tabs.map(renderTab)}
+      {tabs.map((tab, index) => renderTab(tab, index))}
 
       <div
         ref={clipPathContainerRef}
@@ -183,7 +212,7 @@ const TabList = ({
         style={clipPath ? `clip-path: ${clipPath}` : undefined}
         aria-hidden
       >
-        {tabs.map(renderTab)}
+        {tabs.map((tab, index) => renderTab(tab, index, true))}
       </div>
     </div>
   );

--- a/src/components/ui/TabList.tsx
+++ b/src/components/ui/TabList.tsx
@@ -38,6 +38,7 @@ type OwnProps = {
   itemAlignment?: 'vertical' | 'horizontal';
   withFadeMask?: boolean;
   fadeMaskClassName?: string;
+  isDisabled?: boolean;
   onSwitchTab: (index: number) => void;
   renderExtra?: (tab: TabWithProperties, index: number) => TeactNode;
 };
@@ -53,6 +54,7 @@ const TabList = ({
   itemAlignment,
   withFadeMask,
   fadeMaskClassName,
+  isDisabled,
   renderExtra,
   onSwitchTab,
 }: OwnProps) => {
@@ -98,6 +100,8 @@ const TabList = ({
   });
 
   const handleKeyDown = useLastCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (isDisabled) return;
+
     const isNext = e.key === 'ArrowRight';
     if (!isNext && e.key !== 'ArrowLeft') return;
 
@@ -162,8 +166,9 @@ const TabList = ({
           stretched && styles.stretched,
         )}
         role={noInteractive ? undefined : 'tab'}
-        tabIndex={noInteractive ? undefined : (index === focusableTab ? 0 : -1)}
+        tabIndex={noInteractive ? undefined : (index === focusableTab && !isDisabled ? 0 : -1)}
         aria-selected={noInteractive ? undefined : index === activeTab}
+        aria-disabled={noInteractive ? undefined : isDisabled}
         onClick={() => handleTabClick(index)}
         onContextMenu={hasContextActions ? (e) => handleContextMenu(index, e) : undefined}
       >


### PR DESCRIPTION
### Problem

Chat folder tabs (All, Personal, Groups and so on) are plain `<div>`s with a click handler. They have no tab semantics, and nothing inside the tab list is focusable, so keyboard and screen reader users cannot reach or switch folders at all.

### Fix

All of it is in `ui/TabList`.

The container gets `role="tablist"`. Each tab gets `role="tab"` and `aria-selected`. Tabindex is roving, so the whole list is a single tab stop. Left and Right arrows move focus and activate the tab, wrapping at both ends, and they go through the existing `onSwitchTab` prop, so there is no second selection path. A `:focus-visible` outline was added because these elements were never focusable before.

The active indicator renders a mirrored copy of every tab. Those copies get no role, no tabindex and no `aria-selected`, so they stay out of the accessibility tree and out of the tab order.

Arrow navigation starts from the focused element rather than from the `activeTab` prop. The prop lags one render behind, so a held arrow key would otherwise stall on a single tab.

RTL needs no arrow flipping. `TabList` never sets `dir`, so DOM order matches visual order in every locale.

Mouse, touch and swipe are untouched.

### Checks

`npm run check:ts` and `npm run check:css` pass.

Verified in `dev:mocked` with real keyboard input. Roles are correct, there is exactly one `aria-selected` and one `tabIndex=0`, the accessibility tree lists each folder once, arrows wrap both ways, Up and Down are not intercepted, focus survives re-render, no console errors.

Checked with NVDA on Windows. A folder tab is announced as its name, then `tab`, then `selected`, together with its position in the set. Each folder is announced once, so the mirrored copies stay out of the accessibility tree. Arrow navigation announces the newly selected folder.

### Known limits

Forward Tab does not reach the tabs. The search field opens the search panel on focus and that collapses the folder bar. `Shift+Tab` reaches them. This is pre-existing and separate from this change.

`SquareTabList` (search tabs) and the vertical folders sidebar have the same gap. I left them alone to keep this scoped.

Closes #106
