### PR TITLE
Search: Preserve IME composition in controlled inputs

### DIFF
--- a/src/lib/teact/teact-dom.ts
+++ b/src/lib/teact/teact-dom.ts
@@ -723,11 +723,11 @@ function processControlled(tag: string, props: AnyLiteral) {
   } = props;
 
   props.onChange = undefined;
-  props.onInput = (e: ChangeEvent<HTMLInputElement>) => {
+  props.onInput = (e: ChangeEvent<HTMLInputElement> & InputEvent) => {
     onInput?.(e);
     onChange?.(e);
 
-    if (value !== undefined && value !== e.currentTarget.value) {
+    if (!e.isComposing && value !== undefined && value !== e.currentTarget.value) {
       const { selectionStart, selectionEnd } = e.currentTarget;
       const isCaretAtEnd = selectionStart === selectionEnd && selectionEnd === e.currentTarget.value.length;
 


### PR DESCRIPTION
## Problem

The chat message search uses an experimental controlled input. During Chinese IME composition, each intermediate `input` event can restore the DOM value from the previous rendered `value`. This interrupts the active composition and leaves partial Latin letters before a candidate can be selected.

## Fix

Treat the delegated input event as an `InputEvent` and skip controlled-value restoration while `isComposing` is true. Input callbacks still run during composition, and normal controlled-value restoration resumes after the IME commits or cancels the composition.

This is implemented in the shared controlled-input layer so other IME-backed controlled inputs receive the same behavior.

## Checks

- [x] `./node_modules/.bin/tsc --pretty false`
- [x] `npx eslint src/lib/teact/teact-dom.ts`
- [x] `git diff --check`

Closes #533