### PR TITLE
fix: crisp full media for large stickers/custom emoji

### DIFF
--- a/src/components/common/StickerView.tsx
+++ b/src/components/common/StickerView.tsx
@@ -36,6 +36,8 @@ type OwnProps = {
   fullMediaClassName?: string;
   isSmall?: boolean;
   size?: number;
+  /** Prefer full document media (`document{id}`) over `?size=m` preview when shown large. */
+  preferFullMedia?: boolean;
   customColor?: string;
   loopLimit?: number;
   shouldLoop?: boolean;
@@ -60,6 +62,8 @@ type OwnProps = {
 
 const SHARED_PREFIX = 'shared';
 const STICKER_SIZE = 24;
+/** Below this CSS size, low-res preview is OK for list performance; at/above load full media. */
+const FULL_MEDIA_SIZE_THRESHOLD = 64;
 
 const StickerView = ({
   containerRef,
@@ -69,6 +73,7 @@ const StickerView = ({
   fullMediaClassName,
   isSmall,
   size = STICKER_SIZE,
+  preferFullMedia,
   customColor,
   loopLimit,
   shouldLoop = false,
@@ -124,7 +129,15 @@ const StickerView = ({
   const isReadyToMountFullMedia = forceOnHeavyAnimation
     ? hasIntersectedForPlayingRef.current
     : isMountedAfterHeavyAnimation;
-  const shouldForcePreview = !skipPreview && (isUnsupportedVideo || (isStatic ? isSmall : noPlay));
+  // Large stickers/emoji must not stay on `?size=m` preview (blurry upscale), even if
+  // animation is paused (`noPlay`) or the caller marked the slot `isSmall` at a large size.
+  const shouldPreferFullMedia = Boolean(
+    preferFullMedia || !isSmall || size >= FULL_MEDIA_SIZE_THRESHOLD,
+  );
+  const shouldForcePreview = !skipPreview && (
+    isUnsupportedVideo
+    || (!shouldPreferFullMedia && (isStatic ? isSmall : noPlay))
+  );
   const shouldLoadPreview = !skipPreview && (!customColor || shouldForcePreview) && !cachedPreview
     && (!isReadyToMountFullMedia || shouldForcePreview);
   const previewMediaData = useMedia(previewMediaHash, !shouldLoadPreview);


### PR DESCRIPTION
## Summary

- Stops forcing low-res `document{id}?size=m` preview when stickers/custom emoji are shown large (CSS size ≥ 64, not marked `isSmall`, or via new `preferFullMedia`), including animated Lottie/video when `noPlay` would previously keep the preview.
- Tiny list/inline emoji (`isSmall` and size &lt; 64) still use preview for performance.
- Addresses blurry fullscreen / large custom-emoji display reported in #538.

Fixes #538  
Hyperlinks Space tracking: https://github.com/HyperlinksSpace/HyperlinksSpaceProgram/issues/92

## Test plan

- [ ] Open a large single animated custom emoji in a chat (and with animated emoji disabled) — should look crisp, not upscaled `size=m`
- [ ] Open sticker / custom-emoji set modal — stickers at modal size should load full media when static or paused
- [ ] Scroll a chat with many tiny inline custom emoji — still uses preview path (no obvious perf regression)
- [ ] Unsupported video stickers on mobile still fall back to preview


Made with [Cursor](https://cursor.com)